### PR TITLE
Add document about jupyter-org get-involved

### DIFF
--- a/get_involved.md
+++ b/get_involved.md
@@ -1,0 +1,74 @@
+# Get involved
+
+[Issue #27 of docs-team-compass](https://github.com/jupyter/docs-team-compass/issues/27)
+highlights the need for a better "get involved" page in jupyter.org.
+The page, https://jupyter.org/community, as put in the description of the issue,
+could be improved to better guide potential contributors.
+
+> This document does NOT aim to suggest new content, but a list of observations
+> of what information could be removed/moved to make room for a cleaner view.
+
+## An holistic view of community channels
+
+It would be helpfull to have an holistic view of each project's channel
+of communication.
+
+> In the first part of table below, the projects list are taken from the page
+> above (jupyter.org/community).
+> In the second part, the project names were added based on my knowledge of
+> Jupyter projects.
+
+| Project | team-compass | Gitter |
+| - | - | - |
+| Jupyter* | | https://app.gitter.im/#/room/#jupyter_jupyter:gitter.im |
+| IPython | | https://app.gitter.im/#/room/#ipython_ipython:gitter.im |
+| JupyterHub | https://github.com/jupyterhub/team-compass | https://app.gitter.im/#/room/#jupyterhub_jupyterhub:gitter.im |
+| JupyterLab | https://github.com/jupyterlab/team-compass | https://app.gitter.im/#/room/#jupyterlab_jupyterlab:gitter.im & https://app.gitter.im/#/room/#jupyter_jupyterlab:gitter.im & https://app.gitter.im/#/room/#jupyterlab_Lobby:gitter.im |
+| Jupyter-Widgets | https://github.com/jupyter-widgets/team-compass | https://app.gitter.im/#/room/#jupyter-widgets_Lobby:gitter.im & https://app.gitter.im/#/room/#ipython_ipywidgets:gitter.im |
+| Jupyter-Server | https://github.com/jupyter-server/team-compass | https://app.gitter.im/#/room/#jupyter_jupyter_server:gitter.im |
+| Jupyter-Xeus | | https://app.gitter.im/#/room/#QuantStack_Lobby:gitter.im |
+| Jupyter-LSP | | |
+| Voila-dashboards | | https://app.gitter.im/#/room/#QuantStack_Lobby:gitter.im |
+| Binder | | https://app.gitter.im/#/room/#binder-project_binder:gitter.im & https://app.gitter.im/#/room/#jupyterhub_binder:gitter.im |
+| --- | --- | --- |
+Notebook | https://github.com/jupyter/notebook-team-compass | https://app.gitter.im/#/room/#jupyter_notebook:gitter.im |
+Kernels | https://github.com/jupyter/kernels-team-compass | |
+nbviewer | | https://app.gitter.im/#/room/#jupyter_nbviewer:gitter.im |
+nbgrader | | https://app.gitter.im/#/room/#jupyter_nbgrader:gitter.im |
+
+If you're not sure where to direct your question or request, the channels below
+may be a good a good place to start:
+
+- Discourse: https://discourse.jupyter.org
+- Google groups: https://groups.google.com/g/jupyter
+- Stackoverflow: https://stackoverflow.com/questions/tagged/jupyter
+
+## Other community initiatives channels
+
+| Initiative | Google Groups |
+| - | - |
+| Teaching with Jupyter Notebooks | https://groups.google.com/g/jupyter-education |
+| Jupyter at Research Facilities | https://groups.google.com/g/jupyter-research-facilities
+
+## Jupyter-Org duplicated pages
+
+Jupyter.org has a couple of duplicated pages among jupyter.org and docs.jupyter.org:
+
+- Community:
+    - https://jupyter.org/community (as "Get Involved")
+    - https://docs.jupyter.org/en/latest/community/content-community.html
+
+- Contributing:
+    - https://jupyter.org/community (as "Get Involved")
+    - https://docs.jupyter.org/en/latest/contributing/content-contributor.html
+
+I understand those pages are well-paced in the [docs](docs.jupyter.org) website,
+the suggestion is to have the ["Get Involved"](jupyter.org/community)
+page in jupyter.org simply pointing to those in the docs, eliminating
+sections "explore our projects", "live events", "jupyter community calls",
+and maybe "jupyter community workshops" (to be moved to *docs/community*).
+
+## Blog
+
+Advertise [Jupyter blog](https://blog.jupyter.org/) in jupyter.org
+as *Blog* instead of *News* (in the top menu).

--- a/what_is_jupyter.md
+++ b/what_is_jupyter.md
@@ -1,0 +1,94 @@
+# What is Jupyter
+
+[jupyter.org/about]: https://jupyter.org/about
+[subprojects]: https://jupyter.org/governance/list_of_subprojects.html
+
+There is a lot in the name *Jupyter*; the project, the software, the notebooks.
+It is not unusual to fill confused with the many terms around "Jupyter".
+But confusion is never nice so let's try to clarify them.
+
+If you are completely new to *Jupyter*, the [`jupyter.org/about`][jupyter.org/about]
+page is good reading for an overview of the **project**.
+Completely open-source, the software developed by the project grew substantially
+as to be composed by many pieces; those *pieces* (Notebook, Lab, Hub)
+are developed by the different Jupyter [**subprojects**][subprojects]
+
+Let's break "Jupyter" in its components so we can clear them apart
+and have a better view of the *software*.
+
+
+## *Notebook* vs *notebook*
+
+Let's start from the most popular concept, what most of the discussions
+about *Jupyter* talk about: the "notebook".
+
+"Notebook" has two meanings: the notebook file format -- the `.ipynb` files --,
+and the Notebook graphical user interface -- the application -- we use to create
+our notebooks.
+
+
+## *Notebook* and *Lab*
+
+There are two graphical user interface (software) to edit notebooks:
+Jupyter-Notebook and Jupyter-Lab.
+
+As presented in the [*History of Jupyter*](history_of_jupyter.md), Jupyter-Lab
+is an evolution of Jupyter-Notebook to provide a more concise interface to
+the many activities in that environment such as files management, simultaneous
+view of multiple notebooks or parallel views of the notebook.
+
+The Notebook keeps providing the classic interface, that may be advantageous
+for some communities.
+
+## The *Hub*
+
+To many users not used to the management of software systems,
+setting up a Jupyter Notebook or Lab may be an obstacle to the final goal,
+that of data analysis.
+Furthermore, a it is desirable in many scenarios to have a common software
+setup shared among a team of data analists; a multi-user system.
+
+Jupyter-Hub is a multi-user Jupyter system, responsible for managing
+multiple Jupyter Notebook or Lab servers.
+
+## Jupyter Server
+
+In the previous sections we learned the difference -- or similarity -- of
+Jupyter Notebook and Jupyter Lab, and the role of Jupyter Hub in managing
+those *servers*.
+
+The slightly different user interfaces provided by Notebook and Lab are
+backed by the same engine: the Jupyter Server.
+Jupyter Server is responsible for rendering the (`.ipynb`) notebooks,
+managing configurations, and integrating the extensions.
+
+## Kernels
+
+Kernels are at the very core of the Jupyter software ecosystem, they are
+responsible for interpreting the code cells in a notebook.
+When a Jupyter application -- Notebook or Lab, for instance -- is installed,
+a Python kernel is provided by default.
+But, as you may already know, other programming languages can be used in
+notebooks, such as R and Julia, provided the corresponding kernels are
+installed.
+
+Kernels are the abstraction layer between the Jupyter application and
+different programming languages.
+
+## IPython
+
+If you use Python, you know you can run Python code directly in the command-line
+interface through the `python` interactive interpreter (aka, Python *shell*).
+
+IPython is the Python shell with super-powers.
+IPython is where Jupyter started (see [History of Jupyter](history_of_jupyter.md)),
+a command-line interface with high-level functionalities such as the
+[*magic commands*](https://ipython.readthedocs.io/en/stable/interactive/magics.html)
+(available in Jupyter Notebook and Lab).
+
+As a matter of fact, the extension used for Jupyter notebook files, `ipynb`,
+is reminiscent from when Jupyter was simply IPython Notebooks.
+Besides the files extension and magic commands, IPython is very much alive and integrated
+in the Jupyter ecosystem through `ipykernel`, the Python kernel engine.
+(To be more precise and technically correct, the magic commands are
+part of ipykernel's job.)

--- a/what_is_jupyter.md
+++ b/what_is_jupyter.md
@@ -4,17 +4,17 @@
 [subprojects]: https://jupyter.org/governance/list_of_subprojects.html
 
 There is a lot in the name *Jupyter*; the project, the software, the notebooks.
-It is not unusual to fill confused with the many terms around "Jupyter".
+It is not unusual to feel confused with the many terms around "Jupyter".
 But confusion is never nice so let's try to clarify them.
 
 If you are completely new to *Jupyter*, the [`jupyter.org/about`][jupyter.org/about]
 page is good reading for an overview of the **project**.
-Completely open-source, the software developed by the project grew substantially
-as to be composed by many pieces; those *pieces* (Notebook, Lab, Hub)
+Completely open-source, the software developed by the project grew
+into many pieces; those *pieces* (i.e. Notebook, Lab, Hub)
 are developed by the different Jupyter [**subprojects**][subprojects]
 
-Let's break "Jupyter" in its components so we can clear them apart
-and have a better view of the *software*.
+Let's review Jupyter and its components to
+better understand the common terms referring to the *software*.
 
 
 ## *Notebook* vs *notebook*
@@ -23,11 +23,11 @@ Let's start from the most popular concept, what most of the discussions
 about *Jupyter* talk about: the "notebook".
 
 "Notebook" has two meanings: the notebook file format -- the `.ipynb` files --,
-and the Notebook graphical user interface -- the application -- we use to create
+and the graphical user interface -- the application -- used to create
 our notebooks.
 
 
-## *Notebook* and *Lab*
+## Notebook and Lab
 
 There are two graphical user interface (software) to edit notebooks:
 Jupyter-Notebook and Jupyter-Lab.
@@ -40,7 +40,7 @@ view of multiple notebooks or parallel views of the notebook.
 The Notebook keeps providing the classic interface, that may be advantageous
 for some communities.
 
-## The *Hub*
+## Jupyter Hub
 
 To many users not used to the management of software systems,
 setting up a Jupyter Notebook or Lab may be an obstacle to the final goal,


### PR DESCRIPTION
Expand discussion from issue #27 by listing some suggestion to clean up jupyter.org/community page, as well as a table with all the channels (I could) find in Gitter and the projects hosting team-compass repositories.